### PR TITLE
Add image containing Firefox

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -39,3 +39,4 @@ jobs:
       image_name: java-firefox
       subdir: java-firefox
       build_args: ""
+      base_image: java

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -31,3 +31,11 @@ jobs:
       image_name: java
       subdir: java
       build_args: ""
+  build-java-firefox:
+    needs:
+      - build-java
+    uses: ./.github/workflows/container-images.yml
+    with:
+      image_name: java-firefox
+      subdir: java-firefox
+      build_args: ""

--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -13,6 +13,10 @@ on:
       image_name:
         required: true
         type: string
+      base_image:
+        required: false
+        default: "base"
+        type: string
 
 env:
   REGISTRY: ghcr.io/${{ github.repository_owner }}
@@ -67,7 +71,7 @@ jobs:
           build-args: |-
             JAVA_VERSION=${{ matrix.java_version }}
             JDK_DOWNLOAD_URL=${{ matrix.java_url }}
-            BASE_IMAGE=${{ env.REGISTRY }}/artemis-base:${{ matrix.java_version }}
+            BASE_IMAGE=${{ env.REGISTRY }}/artemis-${{ inputs.base_image }}:${{ matrix.java_version }}
             ${{ inputs.build_args }}
           context: ${{ inputs.subdir }}
           containerfiles: ${{ inputs.subdir }}/Dockerfile

--- a/README.adoc
+++ b/README.adoc
@@ -40,6 +40,11 @@ Creates the two world-read/writeable directories
 
 that can be used to cache dependencies between different submissions.
 
+=== Java-Firefox
+
+Contains the same software as `java`.
+Additionally, installs Firefox ESR to enable the execution of Selenium system tests for web applications.
+
 
 == Java version policy
 

--- a/java-firefox/Dockerfile
+++ b/java-firefox/Dockerfile
@@ -1,0 +1,14 @@
+ARG BASE_IMAGE
+FROM --platform=linux/amd64 $BASE_IMAGE
+LABEL maintainer1="Stephan Lukasczyk <stephan@pynguin.eu>"
+
+ENV MAVEN_OPTS="-Dmaven.repo.local=/maven_cache/repository"
+ENV GRADLE_OPTS="-Dorg.gradle.daemon=false"
+
+RUN apt-get update \
+    && apt-get install -y python3 python3-virtualenv python3-git firefox-esr \
+    && mkdir -p /maven_cache/repository \
+    && mkdir -p /gradle_cache \
+    # we do not know as which user/groupid Jenkins runs the build
+    # therefore, create a central cache accessible to everyone
+    && chmod -R a+rwx /maven_cache /gradle_cache

--- a/java-firefox/Dockerfile
+++ b/java-firefox/Dockerfile
@@ -2,13 +2,5 @@ ARG BASE_IMAGE
 FROM --platform=linux/amd64 $BASE_IMAGE
 LABEL maintainer1="Stephan Lukasczyk <stephan@pynguin.eu>"
 
-ENV MAVEN_OPTS="-Dmaven.repo.local=/maven_cache/repository"
-ENV GRADLE_OPTS="-Dorg.gradle.daemon=false"
-
 RUN apt-get update \
-    && apt-get install -y python3 python3-virtualenv python3-git firefox-esr \
-    && mkdir -p /maven_cache/repository \
-    && mkdir -p /gradle_cache \
-    # we do not know as which user/groupid Jenkins runs the build
-    # therefore, create a central cache accessible to everyone
-    && chmod -R a+rwx /maven_cache /gradle_cache
+    && apt-get install -y --no-install-recommends firefox-esr


### PR DESCRIPTION
When executing system tests with Selenium, one wants to have an image with a browser available, too.  We thus provide an image that also installs Firefox to fulfil this requirement.

@b-fein Personally, I believe this is extremely ugly, because I just copied the `Dockerfile` from the `java` image and added the `firefox-esr` package to the install list.  However, if I understood the build pipeline correctly, all images are built on top of `base`, which is reasonable; however, I'd like to have this one actually being built on top of `java`.  Do you know of a more clean solution, avoiding the duplicate code in the `Dockerfile`s, or is this just something we need to live with?