### PR TITLE
Add the static code analysis tool `Perfumator` to all images

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,3 +1,20 @@
+FROM docker.io/library/maven:3-eclipse-temurin-17 AS perfumator-builder
+
+ARG PERFUMATOR_VERSION=0.3.0
+ENV PERFUMATOR_DOWNLOAD_URL=https://git.fim.uni-passau.de/silbereise/perfumator-java/-/archive/v${PERFUMATOR_VERSION}/perfumator-java-v${PERFUMATOR_VERSION}.zip
+
+RUN : \
+    && apt-get update \
+    && apt-get install -y unzip \
+    && wget -q -O perfumator.zip ${PERFUMATOR_DOWNLOAD_URL} \
+    && unzip perfumator.zip \
+    && cd perfumator-java-v${PERFUMATOR_VERSION} \
+    && mvn -B -DskipTests package \
+    && cp target/perfumator-java-${PERFUMATOR_VERSION}-jar-with-dependencies.jar /perfumator-java.jar \
+    && :
+
+################################################################################
+
 FROM docker.io/library/debian:bookworm-slim
 LABEL maintainer1="Benedikt Fein <fein@fim.uni-passau.de>" maintainer2="Christian Bachmaier <bachmaier@fim.uni-passau.de>"
 
@@ -7,11 +24,11 @@ ARG JDK_DOWNLOAD_URL
 ARG MAVEN_VERSION
 ARG MAVEN_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
 
-ENV JAVA_HOME /usr/local/java/jdk-$JAVA_VERSION
-ENV PATH $JAVA_HOME/bin:$PATH
-ENV MAVEN_HOME /usr/local/share/maven
+ENV JAVA_HOME=/usr/local/java/jdk-$JAVA_VERSION
+ENV PATH=$JAVA_HOME/bin:$PATH
+ENV MAVEN_HOME=/usr/local/share/maven
 # Default to UTF-8 file.encoding
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive TZ=Europe/Berlin apt-get install --no-install-recommends -y ca-certificates p11-kit wget curl procps git \
@@ -37,3 +54,6 @@ RUN apt-get update \
 # create an alias for whoami as we do not know the userid,
 # but some tools (dejagnu) needs to know the user name for whatever reason
 COPY whoami /usr/bin/whoami
+
+COPY perfumator-java /usr/bin/perfumator-java
+COPY --from=perfumator-builder /perfumator-java.jar /usr/local/share/perfumator-java.jar

--- a/base/perfumator-java
+++ b/base/perfumator-java
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+
+java -jar /usr/local/share/perfumator-java.jar "$@"


### PR DESCRIPTION
### Motivation
In order to provide students with positive feedback, the tool `Perfumator` (https://fimgit.fim.uni-passau.de/silbereise/perfumator-java) is added to the base image and therefore all other images. It is not enough to only add the tool in the dejagnu image, since Perfumes should also be part of the static code analysis of the Software Testing course.

### Technical Details
The Perfumator cannot be built with any Java version later than Java 20, and the setup guide explicitly states that Java 17 should be used, therefore we install Java 17 for the build. In the second stage of the base Dockerfile, the actual Java version and Maven are installed, and the Perfumator `jar` is copied from the first step to the final image.